### PR TITLE
Fix FearDistancePatch for update v50

### DIFF
--- a/FairGiants/Patches/ForestGiantAIPatch.cs
+++ b/FairGiants/Patches/ForestGiantAIPatch.cs
@@ -48,7 +48,7 @@ public class ForestGiantAIPatch {
 		CodeMatcher matcher = new CodeMatcher(instructions)
 			// Match method call for EnemyAI::GetAllPlayersInLineOfSight
 			.MatchForward(true,
-				new CodeMatch(OpCodes.Call, AccessTools.Method(typeof(EnemyAI), "HasLineOfSightToPosition"))
+				new CodeMatch(OpCodes.Call, AccessTools.Method(typeof(EnemyAI), "CheckLineOfSightForPosition"))
 			)
 
 			// Match argument loading ldc.i4.s aka range


### PR DESCRIPTION
Lethal Company v50 changed the `HasLineOfSightToPosition` method in `EnemyAI`, adding new parameters and renaming it to `CheckLineOfSightForPosition`. Loading the current version of FairGiants in v50 causes HarmonyX to throw an exception when the plugin is loaded, as it fails to find the old method in the `FearDistancePatch` transpiler.

Just updating the name of the method it searches for seems to be enough to make the plugin work perfectly in v50, despite other forest keeper AI changes.

Note that this change breaks v49 compatibility, and v50 is still only available via beta branch. It probably wouldn't do much good to publish a plugin update until v50 is released proper.